### PR TITLE
Speed improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This library uses [Compatible Versioning](https://github.com/staltz/comver#readm
 
 ## [Unreleased]
 
+## [v1.6]
+### Changed
+- Improved the performance of the noise2D noise3D noise4D implementations.
+- Changed the `files` field in the package json to only include the lib (and additional files).
+
+## [v1.5]
+
 ## [v1.4]
 ### Fixed
 - Contribution calculations for 3D and 4D.
@@ -12,6 +19,8 @@ This library uses [Compatible Versioning](https://github.com/staltz/comver#readm
 ### Added
 - Define `noise2D`, `noise3D`, and `noise4D` functions.
 
-[Unreleased]: https://github.com/joshforisha/open-simplex-noise-js/compare/v1.4...HEAD
+[Unreleased]: https://github.com/joshforisha/open-simplex-noise-js/compare/v1.6...HEAD
+[v1.6]: https://github.com/joshforisha/open-simplex-noise-js/compare/v1.5...v1.6
+[v1.5]: https://github.com/joshforisha/open-simplex-noise-js/compare/v1.4...v1.5
 [v1.4]: https://github.com/joshforisha/open-simplex-noise-js/compare/v1.0...v1.4
 [v1.0]: https://github.com/joshforisha/open-simplex-noise-js/releases/tag/v1.0

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "bugs": {
     "url": "https://github.com/joshforisha/open-simplex-noise-js/issues"
   },
+  "files": [
+    "lib"
+  ],
   "main": "lib/index",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-simplex-noise",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "OpenSimplex noise for TypeScript/JavaScript",
   "keywords": [
     "noise",
@@ -21,6 +21,9 @@
   "files": [
     "lib"
   ],
+  "contributors": [
+    "Florian Völker <Neirolf2030@web.de>"
+  ],
   "main": "lib/index",
   "types": "lib/index.d.ts",
   "scripts": {
@@ -29,6 +32,7 @@
     "watch": "tsc --watch"
   },
   "devDependencies": {
+    "prettier": "^1.16.4",
     "typescript": "^2.7.2"
   }
 }


### PR DESCRIPTION
So I took some time and overhauled the noise2D noise3D noise4D functions to be (much) more efficient. There were several things which were not needed and, in my opinion, made the code less readable.

## Changes

### `explode` constructs

For example code like this:

```js
const [a ,b] = [1, 2];
```

is making the code (in my opinion) hard to read and not giving any benefit. In addition they are costing a lot of performance since an array has to be created, adressed and then the variables have to be declared.

### `hash` calculation with `TypedArray`

I am assuming that you tried to translate the code from the Java original to JavaScript (which you did very well!) and just tried to make sure everything worked the same waay.

The funny thing is (I did not knew this either before I worked on your code) that [bitwise operator treat their operands as sequence of 32 bits](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators) which renders the TypeArray redundant.

### `while` loop instead of `for` loop

This was just a little thing I found. You had used a while loop to traverse in your "linked list" like construct, which is perfectly fine but I thought it would be more readable to write it as an for loop.

### `files` field in the `package.json`

I have added the [`files` field](https://docs.npmjs.com/files/package.json#files) in your `package.json` which now prevents npm from packaging all files present in the directory and only the necessary files. Files like `.travis.yml` `package-lock.json` `tsconfig.json` and so on are now not a part of the package anymore.

## Speed Change

I have used the [benchmark](https://www.npmjs.com/package/benchmark) package to masseur the performance of the individual functions. I will create another pull request to make this easier to test in development.

The `ops/sec` / the `relativ` columns are important. I was able to improve the perfomance of the `noise2D` so it is now about 15 times faster then the old version.

I think there is more to improve, since the Java version is able to perform about 20 million `ops/sec` but you can not really compare Java vs JavaScript.

I will upload the testing I used and comment a link, so you can test it yourself. If I have more time I will try to improve the creation time and add some testing since you have currently no error check.

EDIT: Here is the link to the testing repo.: https://github.com/Feirell/speed-test-osn

```text
noise 2D at 2.5
                    name    ops/sec     MoE samples relativ
      open-simplex-noise    972,169 ± 0.81%      90       1
open-simplex-noise-opted 14,308,701 ± 0.25%      95   14.72

noise 3D at 2.5
                    name   ops/sec     MoE samples relativ
      open-simplex-noise   918,338 ± 1.38%      89       1
open-simplex-noise-opted 5,975,073 ± 0.46%      95    6.51

noise 4D at 2.5
                    name   ops/sec     MoE samples relativ
      open-simplex-noise   677,597 ± 2.26%      78       1
open-simplex-noise-opted 2,810,339 ± 0.53%      96    4.15
```