### PR TITLE
Added exports to noise types

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/joshforisha/open-simplex-noise-js/issues"
   },
   "files": [
-    "lib"
+    "src"
   ],
   "contributors": [
     "Florian Völker <Neirolf2030@web.de>"

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,11 +22,11 @@ import {
   p4D
 } from "./constants";
 
-type Noise2D = (x: number, y: number) => number;
+export type Noise2D = (x: number, y: number) => number;
 
-type Noise3D = (x: number, y: number, z: number) => number;
+export type Noise3D = (x: number, y: number, z: number) => number;
 
-type Noise4D = (x: number, y: number, z: number, w: number) => number;
+export type Noise4D = (x: number, y: number, z: number, w: number) => number;
 
 interface Contribution2D {
   dx: number;


### PR DESCRIPTION
Fixes this issue
`Namespace '"***"' has no exported member 'Noise2D'.ts(2694)`

This Noise* types cannot be used within typescript files. They weren't exported.